### PR TITLE
Update to latest quarkus and iris

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,7 @@
 version: 2
-registries:
-  gid-nexus:
-    type: maven-repository
-    url: https://repository.internal.globalid.dev/repository/maven-internal-group/
-    username: ${{secrets.NEXUS_USERNAME}}
-    password: ${{secrets.NEXUS_PASSWORD}}
-
 updates:
   - package-ecosystem: maven
     directory: "/"
-    registries:
-      - gid-nexus
     schedule:
       interval: daily
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,15 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <version.quarkus-rabbitmq-client>3.0.0</version.quarkus-rabbitmq-client>
+        <version.quarkus-rabbitmq-client>3.0.1</version.quarkus-rabbitmq-client>
         <version.hamcrest>2.2</version.hamcrest>
-        <compiler-plugin.version>3.11.0</compiler-plugin.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.version>3.2.2.Final</quarkus.platform.version>
-        <surefire-plugin.version>3.0.0</surefire-plugin.version>
-        <version.iris-events>5.0.7</version.iris-events>
+        <quarkus.platform.version>3.8.3</quarkus.platform.version>
+        <surefire-plugin.version>3.2.5</surefire-plugin.version>
+        <version.iris-events>6.0.4</version.iris-events>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -14,6 +14,5 @@ quarkus.amqp.port=5672
 quarkus.datadog.enabled=false
 quarkus.log.console.json=false
 quarkus.log.level=INFO
-quarkus.log.category."id.global".level=TRACE
 
 quarkus.rabbitmq.devservices.port=5672


### PR DESCRIPTION
This pull request includes changes to the project's configuration and dependencies. The most important changes include the removal of a maven repository from the `.github/dependabot.yml` file, updates to several dependency versions in the `pom.xml` file, and the removal of a logging category from the `src/main/resources/application-test.properties` file.

Dependency and configuration changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L2-L13): Removed the `gid-nexus` maven repository from the `registries` section. This change implies that the project will now rely on the default maven repositories for dependency updates.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L15-R23): Updated several dependency versions, including `quarkus-rabbitmq-client`, `compiler-plugin`, `quarkus.platform`, `surefire-plugin`, and `iris-events`. This indicates that the project is now using more recent versions of these dependencies, which could include new features, bug fixes, or performance improvements.

Logging changes:

* [`src/main/resources/application-test.properties`](diffhunk://#diff-7262e6545724c8dbe1b3c64b35b6f9b737cf0aaf7242725378a0d6574e6bed19L17): Removed the `"id.global"` logging category. This means that logs from this category will now follow the default logging level instead of the previously specified `TRACE` level.