### PR TITLE
DO-2723 Change ghcr image path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,10 +18,10 @@ jobs:
         include:
           - name: "JVM"
             dockerfile: src/main/docker/Dockerfile.jvm
-            image: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+            image: ghcr.io/${{ github.repository_owner }}/manager
           - name: "Native"
             dockerfile: src/main/docker/Dockerfile.multistage
-            image: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}-native
+            image: ghcr.io/${{ github.repository_owner }}/manager-native
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.name }}
       cancel-in-progress: true


### PR DESCRIPTION
Change URL of docker image from `ghcr.io/iris-events/iris-events/iris-manager` to `ghcr.io/iris-events/manager`, to match iris-router and iris-subscription.
